### PR TITLE
Features/deregister

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,14 @@ nlc.addSlotType({
 });
 ```
 
+To remove a SlotType, you can call:
+
+```javascript
+nlc.removeSlotType("SLOT_TYPE"):
+```
+
+however, you can only do this if no intents rely on the slot type.
+
 ## Registering Intents
 
 To register an intent, call `nlc.registerIntent` with an Intent object with the attributes:
@@ -289,7 +297,23 @@ nlc.registerIntent({
 ```
 
 You can also add an utterance to an existing intent (if you're generating them from some learning
-algorithm or something) by calling `nlc.addUtterance('INTENT_NAME', 'New utterance');`
+algorithm or something) by calling:
+
+```javascript
+nlc.addUtterance('INTENT_NAME', 'New utterance');`
+```
+
+or remove one by calling:
+
+```javascript
+nlc.removeUtterance('INTENT_NAME', 'New utterance');`
+```
+
+You can remove an entire intent by calling:
+
+```javascript
+nlc.deregisterIntent('INTENT_NAME')`
+```
 
 ## Handling Commands
 
@@ -372,6 +396,12 @@ nlc.handleCommand({
   userId: "12345",
   command: `I'd wrestle a bear.`
 });
+```
+
+To de-register a question, call:
+
+```javascript
+nlc.deregisterQuestion('QUESTION_NAME');
 ```
 
 ## Handling commands that don't match

--- a/src/NaturalLanguageCommander.ts
+++ b/src/NaturalLanguageCommander.ts
@@ -96,6 +96,33 @@ class NaturalLanguageCommander {
     _.forEach(intent.utterances, (utterance: string): void => {
       this.matchers.push(new Matcher(this.slotTypes, intent, utterance));
     });
+
+    return true;
+  };
+
+  /**
+   * De-register an intent. Bound to this.
+   * @param intentName
+   * @returns true if removed, false if the intent doesn't exist.
+   */
+  public deregisterIntent = (intentName: string): boolean => {
+    if (!this.doesIntentExist(intentName)) {
+      return false;
+    }
+
+    // Remove the name from the name list.
+    this.intentNames = _.reject(this.intentNames, name => name === intentName);
+
+    // Remove the intent.
+    this.intents = _.reject(this.intents, { intent: intentName });
+
+    // Remove matchers for the intent.
+    this.matchers = _.reject(
+      this.matchers,
+      matcher => matcher.intent.intent === intentName
+    );
+
+    return true;
   };
 
   /**

--- a/src/NaturalLanguageCommander.ts
+++ b/src/NaturalLanguageCommander.ts
@@ -163,6 +163,8 @@ class NaturalLanguageCommander {
 
     // Set up the question.
     this.questions[questionData.name] = new Question(this, questionData);
+
+    return true;
   };
 
   /**

--- a/src/lib/Matcher.ts
+++ b/src/lib/Matcher.ts
@@ -20,6 +20,8 @@ type ISlotMapping = {
  * Matches a utterance and slots against a command.
  */
 class Matcher {
+  /** The utterance used to set up the Matcher, for finding to remove. */
+  public originalUtterance: string;
   /** The regexp used to match against a command. */
   private regExp: RegExp;
   /** Map of the intent's slot names to slot types. */
@@ -36,6 +38,8 @@ class Matcher {
     public intent: IIntent,
     utterance: string
   ) {
+    this.originalUtterance = utterance;
+
     const slots: IIntentSlot[] = this.intent.slots;
     const slotMapping: IIntentSlot[] = [];
 

--- a/src/test/nlc.ts
+++ b/src/test/nlc.ts
@@ -43,6 +43,41 @@ describe("NLC", () => {
     });
   });
 
+  describe("deregistering", () => {
+    describe("deregisterIntent", () => {
+      describe("given some intents", () => {
+        beforeEach(() => {
+          nlc.registerIntent({
+            intent: "REMOVE_ME",
+            callback: utils.matchCallback,
+            utterances: ["I shouldn't match"]
+          });
+          nlc.registerIntent({
+            intent: "TEST",
+            callback: utils.matchCallback,
+            utterances: ["test"]
+          });
+
+          nlc.addUtterance("REMOVE_ME", "I also shouldn't match");
+
+          nlc.deregisterIntent("REMOVE_ME");
+        });
+
+        it("won't match after a deregister", (done) => {
+          utils.expectCommandNotToMatch("I shouldn't match", done);
+        });
+
+        it("won't match added utterances after a deregister", (done) => {
+          utils.expectCommandNotToMatch("I also shouldn't match", done);
+        });
+
+        it("doesn't effect other intents", (done) => {
+          utils.expectCommandToMatch("test", done);
+        });
+      });
+    });
+  });
+
   describe("slot types", () => {
     describe("STRING", () => {
       beforeEach(() => {

--- a/src/test/nlc.ts
+++ b/src/test/nlc.ts
@@ -44,35 +44,88 @@ describe("NLC", () => {
   });
 
   describe("deregistering", () => {
-    describe("deregisterIntent", () => {
-      describe("given some intents", () => {
-        beforeEach(() => {
-          nlc.registerIntent({
-            intent: "REMOVE_ME",
-            callback: utils.matchCallback,
-            utterances: ["I shouldn't match"]
-          });
-          nlc.registerIntent({
-            intent: "TEST",
-            callback: utils.matchCallback,
-            utterances: ["test"]
-          });
-
-          nlc.addUtterance("REMOVE_ME", "I also shouldn't match");
-
-          nlc.deregisterIntent("REMOVE_ME");
+    describe("given some intents", () => {
+      beforeEach(() => {
+        nlc.registerIntent({
+          intent: "REMOVE_ME",
+          callback: utils.matchCallback,
+          utterances: ["I shouldn't match"]
+        });
+        nlc.registerIntent({
+          intent: "TEST",
+          callback: utils.matchCallback,
+          utterances: ["test"]
         });
 
-        it("won't match after a deregister", (done) => {
+        nlc.addUtterance("REMOVE_ME", "I also shouldn't match");
+      });
+
+      describe("deregisterIntent", () => {
+        beforeEach(() => {
+          nlc.deregisterIntent("REMOVE_ME");
+        });
+        it("won't match after a deregister", done => {
           utils.expectCommandNotToMatch("I shouldn't match", done);
         });
 
-        it("won't match added utterances after a deregister", (done) => {
+        it("won't match added utterances after a deregister", done => {
           utils.expectCommandNotToMatch("I also shouldn't match", done);
         });
 
-        it("doesn't effect other intents", (done) => {
+        it("doesn't effect other intents", done => {
           utils.expectCommandToMatch("test", done);
+        });
+      });
+
+      describe("removeUtterance", () => {
+        beforeEach(() => {
+          nlc.removeUtterance("REMOVE_ME", "I shouldn't match");
+        });
+        it("removes an utterance", done => {
+          utils.expectCommandNotToMatch("I shouldn't match", done);
+        });
+
+        it("doesn't remove other utterances", done => {
+          utils.expectCommandToMatch("I also shouldn't match", done);
+        });
+      });
+
+      describe("removeSlotType", () => {
+        beforeEach(() => {
+          nlc.addSlotType({
+            type: "STRING_TYPE",
+            matcher: "TEST"
+          });
+        });
+
+        describe("without any matching intents", () => {
+          it("should work", () => {
+            expect(() => {
+              nlc.removeSlotType("STRING_TYPE");
+            }).not.to.throw();
+          });
+        });
+
+        describe("with a matching intent", () => {
+          beforeEach(() => {
+            nlc.registerIntent({
+              intent: "STRING_TEST",
+              callback: utils.matchCallback,
+              slots: [
+                {
+                  name: "String",
+                  type: "STRING_TYPE"
+                }
+              ],
+              utterances: ["test {String} test"]
+            });
+          });
+
+          it("should throw an error", () => {
+            expect(() => {
+              nlc.removeSlotType("STRING_TYPE");
+            }).to.throw("NLC: You can't remove the STRING_TYPE Slot Type while the STRING_TEST intent relies on it.");
+          });
         });
       });
     });
@@ -312,28 +365,32 @@ describe("NLC", () => {
 
     describe("custom", () => {
       describe("duplicates", () => {
-        it("should throw errors", done => {
-          let error;
-
+        beforeEach(() => {
           nlc.addSlotType({
             type: "STRING_TYPE",
             matcher: "TEST"
           });
+        });
 
+        it("should throw errors", () => {
           // Duplicate the type (this should throw an error),
-          try {
+          expect(() => {
             nlc.addSlotType({
               type: "STRING_TYPE",
               matcher: "ANOTHER_TEST"
             });
-          } catch (e) {
-            // Save the error message.
-            error = e;
-          }
+          }).to.throw();
+        });
 
-          // There should have been an error message.
-          expect(error).to.exist;
-          done();
+        it("should work if the slot type has been removed", () => {
+          nlc.removeSlotType("STRING_TYPE");
+
+          expect(() => {
+            nlc.addSlotType({
+              type: "STRING_TYPE",
+              matcher: "ANOTHER_TEST"
+            });
+          }).not.to.throw();
         });
       });
 
@@ -646,6 +703,15 @@ describe("NLC", () => {
 
     it("should reject from ask when the question name does not exist", done => {
       nlc.ask("BAD").catch((status: boolean) => {
+        expect(status).to.be.false;
+        done();
+      });
+    });
+
+    it("should reject from ask when the question name has been deregistered", done => {
+      nlc.deregisterQuestion("QUESTION");
+
+      nlc.ask("QUESTION").catch((status: boolean) => {
         expect(status).to.be.false;
         done();
       });


### PR DESCRIPTION
# Goals
Add de-register methods for Intents, Questions, SlotTypes, and Utterances, per https://github.com/will-wow/natural-language-commander/issues/2

# Implementation
- Add to the NLC class:
`removeSlotType`
`deregisterIntent`
`deregisterQuestion`
`removeUtterance`
- Have `removeSlotType` throw an error if an intent exists that's using that SlotType, since otherwise that intent will stop working in weird ways.
